### PR TITLE
Fixing branch references in workflows

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-    - main
+    - master
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,13 +1,13 @@
 on:
   push:
     branches:
-    - main
+    - master
     - 'release/**'
     - 'cicd/**'
     - dev
   pull_request:
     branches:
-    - main
+    - master
     - 'release/**'
     - 'cicd/**'
     - dev


### PR DESCRIPTION
To use master instead of main, which is non-existent