### PR TITLE
Fixing build command for backboi

### DIFF
--- a/backboi/Dockerfile
+++ b/backboi/Dockerfile
@@ -7,6 +7,6 @@ COPY . .
 RUN go mod download && \
     go mod verify && \
     mkdir /build && \
-    go build -v -o /build/server ./...
+    go build -v -o /build/server .
 
 ENTRYPOINT [ "/build/server" ]


### PR DESCRIPTION
Instead of building packages recursively, only building package from where main.go exists